### PR TITLE
v1.1.0 – W′ Alerts, Recovery During Stops & Responsive UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ configure<com.android.build.api.dsl.ApplicationExtension> {
         applicationId = "com.itl.wprimeext"
         minSdk = 23
         targetSdk = 37
-        versionCode = 9
-        versionName = "1.0.1"
+        versionCode = 10
+        versionName = "1.1.0"
         base.archivesName.set("WPrimeExtension-v${versionName}")
     }
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -2,10 +2,10 @@
   "label": "W Prime Extension",
   "packageName": "com.itl.wprimeext",
   "iconUrl": "https://github.com/apopovsky/WPrimeKarooExtension/releases/latest/download/wprime-icon.png",
-  "latestApkUrl": "https://github.com/apopovsky/WPrimeKarooExtension/releases/latest/download/WPrimeExtension-v1.0.1-release.apk",
-  "latestVersion": "1.0.1",
-  "latestVersionCode": 9,
+  "latestApkUrl": "https://github.com/apopovsky/WPrimeKarooExtension/releases/latest/download/WPrimeExtension-v1.1.0-release.apk",
+  "latestVersion": "1.1.0",
+  "latestVersionCode": 10,
   "developer": "ITL",
   "description": "W Prime Extension for Hammerhead Karoo that calculates anaerobic energy balance in real-time during rides.",
-  "releaseNotes": "Bug fixes: Fixed manifest URLs for proper updates, corrected CI/CD release workflow permissions."
+  "releaseNotes": "v1.1.0: W' threshold alerts (DROP/REPLENISH), W'bal recovery during stops/autopause, responsive text sizing, consistent field label size, kJ display fix."
 }

--- a/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeExtension.kt
+++ b/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeExtension.kt
@@ -54,7 +54,7 @@ import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class)
 @AndroidEntryPoint
-class WPrimeExtension : KarooExtension("wprime-id", "1.0") {
+class WPrimeExtension : KarooExtension("wprime-id", "1.1") {
     @Inject
     lateinit var karooSystem: KarooSystemService
 
@@ -173,7 +173,7 @@ class WPrimeExtension : KarooExtension("wprime-id", "1.0") {
     @SuppressLint("UnspecifiedRegisterReceiverFlag")
     override fun onCreate() {
         super.onCreate()
-        WPrimeLogger.i(WPrimeLogger.Module.EXTENSION, LogConstants.EXTENSION_STARTED + " - Version 1.0")
+        WPrimeLogger.i(WPrimeLogger.Module.EXTENSION, LogConstants.EXTENSION_STARTED + " - Version 1.1.0")
 
         serviceJob = CoroutineScope(Dispatchers.IO).launch {
             karooSystem.connect { connected ->


### PR DESCRIPTION
## What's Changed

### 🔔 W′ Threshold Alerts
Configure alerts that fire during a ride when your W′ balance crosses a threshold in either direction:

- **DROP alert** — triggers when W′ falls *through* a percentage (e.g. drops below 40%)
- **REPLENISH alert** — triggers when W′ rises *through* a percentage (e.g. recovers above 60%)
- Per-alert **sound toggle** with distinct beep patterns (critical / warning / standard)
- **5-minute cooldown** per alert to avoid spam during repeated efforts
- In-ride **toast overlay** (auto-dismisses after ~10 s) — visible on the ride screen
- **Test button** in the Alerts settings tab to preview an alert without riding
- Multiple independent alerts supported, all persisted across rides

### 🔋 W′bal Recovery During Stops
W′bal no longer freezes during autopause, traffic stops, or coffee breaks:

- A background **recovery ticker** fires every 3 s in all three calculation contexts (stream, view, FIT recording)
- If no power sample arrives for **5+ seconds**, the model injects a 0 W update and applies the correct exponential recovery over the exact elapsed time
- All 6 supported models (Skiba 2012/2014, Bartram, Caen-Lievens, Chorley, Weigend) benefit automatically — no model math changed
- Behaviour is physiologically correct: short traffic light stops → minimal recovery; 1-hour coffee stop → full W′ recovery

### 🖥️ Responsive Text Sizing
Data field text now scales correctly based on actual field dimensions:

- Uses `ViewConfig.viewSize` (real pixels) instead of `LocalSize.current` (returns `NaN` on Karoo)
- Field classification system: **LARGE / MEDIUM_WIDE / MEDIUM / SMALL** based on width × height
- Dynamic `maxSp` scaling per class: 3.0× / 2.2× / 1.8× / 1.5×
- Width-factor adjustment prevents text truncation for 3–6 character values in narrow columns

### 🏷️ Consistent Field Label Size
The field header (e.g. "W′ (kJ)", "%W′") now looks the same size regardless of layout:

- **Wide field** (full-width): 20 sp text · 30 dp icon — comparable to Karoo's native "3S POWER" header
- **Narrow field** (single column): 18 sp text · 26 dp icon (0.90× ratio)
- Replaces aggressive area-based scaling that made headers look tiny in large fields

### 🔧 Other Fixes
- kJ field now displays in **kJ with 1 decimal** (e.g. `12.0`) instead of raw Joules
- Smoother value text transition between 2 → 3 character values in narrow fields
- FIT developer fields (`WPrimeJ`, `WPrimePct`) now recover correctly during paused segments

---

**Version bump:** `1.0.1` → `1.1.0` (versionCode 9 → 10)