### PR TITLE
Release: bump version to 1.1.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ configure<com.android.build.api.dsl.ApplicationExtension> {
         applicationId = "com.itl.wprimeext"
         minSdk = 23
         targetSdk = 37
-        versionCode = 10
-        versionName = "1.1.0"
+        versionCode = 11
+        versionName = "1.1.1"
         base.archivesName.set("WPrimeExtension-v${versionName}")
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,6 +32,7 @@ configure<com.android.build.api.dsl.ApplicationExtension> {
     }
 
     buildFeatures {
+        buildConfig = true
         viewBinding = true
         compose = true
     }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -2,10 +2,10 @@
   "label": "W Prime Extension",
   "packageName": "com.itl.wprimeext",
   "iconUrl": "https://github.com/apopovsky/WPrimeKarooExtension/releases/latest/download/wprime-icon.png",
-  "latestApkUrl": "https://github.com/apopovsky/WPrimeKarooExtension/releases/latest/download/WPrimeExtension-v1.1.0-release.apk",
-  "latestVersion": "1.1.0",
-  "latestVersionCode": 10,
+  "latestApkUrl": "https://github.com/apopovsky/WPrimeKarooExtension/releases/latest/download/WPrimeExtension-v1.1.1-release.apk",
+  "latestVersion": "1.1.1",
+  "latestVersionCode": 11,
   "developer": "ITL",
   "description": "W Prime Extension for Hammerhead Karoo that calculates anaerobic energy balance in real-time during rides.",
-  "releaseNotes": "v1.1.0: W' threshold alerts (DROP/REPLENISH), W'bal recovery during stops/autopause, responsive text sizing, consistent field label size, kJ display fix."
+  "releaseNotes": "v1.1.1: Maintenance release with version bump and publishing updates."
 }

--- a/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeExtension.kt
+++ b/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeExtension.kt
@@ -54,7 +54,7 @@ import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class)
 @AndroidEntryPoint
-class WPrimeExtension : KarooExtension("wprime-id", "1.1") {
+class WPrimeExtension : KarooExtension("wprime-id", "1.1.1") {
     @Inject
     lateinit var karooSystem: KarooSystemService
 
@@ -173,7 +173,7 @@ class WPrimeExtension : KarooExtension("wprime-id", "1.1") {
     @SuppressLint("UnspecifiedRegisterReceiverFlag")
     override fun onCreate() {
         super.onCreate()
-        WPrimeLogger.i(WPrimeLogger.Module.EXTENSION, LogConstants.EXTENSION_STARTED + " - Version 1.1.0")
+        WPrimeLogger.i(WPrimeLogger.Module.EXTENSION, LogConstants.EXTENSION_STARTED + " - Version 1.1.1")
 
         serviceJob = CoroutineScope(Dispatchers.IO).launch {
             karooSystem.connect { connected ->

--- a/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeExtension.kt
+++ b/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeExtension.kt
@@ -21,6 +21,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import com.itl.wprimeext.BuildConfig
 import com.itl.wprimeext.utils.LogConstants
 import com.itl.wprimeext.utils.WPrimeLogger
 import dagger.hilt.android.AndroidEntryPoint
@@ -54,7 +55,7 @@ import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class)
 @AndroidEntryPoint
-class WPrimeExtension : KarooExtension("wprime-id", "1.1.1") {
+class WPrimeExtension : KarooExtension("wprime-id", BuildConfig.VERSION_NAME) {
     @Inject
     lateinit var karooSystem: KarooSystemService
 
@@ -173,7 +174,10 @@ class WPrimeExtension : KarooExtension("wprime-id", "1.1.1") {
     @SuppressLint("UnspecifiedRegisterReceiverFlag")
     override fun onCreate() {
         super.onCreate()
-        WPrimeLogger.i(WPrimeLogger.Module.EXTENSION, LogConstants.EXTENSION_STARTED + " - Version 1.1.1")
+        WPrimeLogger.i(
+            WPrimeLogger.Module.EXTENSION,
+            LogConstants.EXTENSION_STARTED + " - Version ${BuildConfig.VERSION_NAME}",
+        )
 
         serviceJob = CoroutineScope(Dispatchers.IO).launch {
             karooSystem.connect { connected ->


### PR DESCRIPTION
## What this PR does
- Bumps Android app version to `1.1.1`
- Increments `versionCode` to `11`
- Updates extension service version string to `1.1.1`
- Updates `app/manifest.json` metadata (`latestVersion`, `latestVersionCode`, APK URL, release notes)

## Files changed
- `app/build.gradle.kts`
- `app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeExtension.kt`
- `app/manifest.json`

## Notes
- This is a release metadata/versioning update only; no functional behavior changes.