### PR TITLE
[codex] Add Karoo FTP critical power source

### DIFF
--- a/app/src/main/kotlin/com/itl/wprimeext/ConfigurationScreen.kt
+++ b/app/src/main/kotlin/com/itl/wprimeext/ConfigurationScreen.kt
@@ -51,15 +51,19 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.itl.wprimeext.extension.AlertType
+import com.itl.wprimeext.extension.CriticalPowerSource
+import com.itl.wprimeext.extension.KAROO_FTP_TO_CRITICAL_POWER_FACTOR
 import com.itl.wprimeext.extension.WPrimeConfiguration
 import com.itl.wprimeext.extension.WPrimeModelType
 import com.itl.wprimeext.extension.WPrimeSettings
+import com.itl.wprimeext.extension.resolveCriticalPower
 import com.itl.wprimeext.ui.components.AlertItem
 import com.itl.wprimeext.ui.components.CompactSettingField
 import com.itl.wprimeext.ui.components.NewAlertDialog
 import com.itl.wprimeext.ui.theme.WPrimeExtensionTheme
 import com.itl.wprimeext.ui.viewmodel.WPrimeConfigViewModel
 import com.itl.wprimeext.ui.viewmodel.WPrimeConfigViewModelFactory
+import io.hammerhead.karooext.KarooSystemService
 
 /**
  * Stateful composable that provides the ViewModel and state to the stateless layout.
@@ -68,17 +72,21 @@ import com.itl.wprimeext.ui.viewmodel.WPrimeConfigViewModelFactory
 fun ConfigurationScreen() {
     val context = LocalContext.current
     val wPrimeSettings = WPrimeSettings(context)
+    val karooSystem = remember { KarooSystemService(context.applicationContext) }
     val viewModel: WPrimeConfigViewModel = viewModel(
-        factory = WPrimeConfigViewModelFactory(wPrimeSettings),
+        factory = WPrimeConfigViewModelFactory(wPrimeSettings, karooSystem),
     )
 
     val configuration by viewModel.configuration.collectAsState()
+    val karooFtp by viewModel.karooFtp.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
 
     ConfigurationScreenLayout(
         isLoading = isLoading,
         configuration = configuration,
+        karooFtp = karooFtp,
         onCriticalPowerChange = viewModel::updateCriticalPower,
+        onUseKarooFtpForCriticalPowerChange = viewModel::updateUseKarooFtpForCriticalPower,
         onAnaerobicCapacityChange = viewModel::updateAnaerobicCapacity,
         onTauRecoveryChange = viewModel::updateTauRecovery,
         onKInChange = viewModel::updateKIn,
@@ -113,7 +121,9 @@ fun ConfigurationScreen() {
 fun ConfigurationScreenLayout(
     isLoading: Boolean,
     configuration: WPrimeConfiguration,
+    karooFtp: Int?,
     onCriticalPowerChange: (Double) -> Unit,
+    onUseKarooFtpForCriticalPowerChange: (Boolean) -> Unit,
     onAnaerobicCapacityChange: (Double) -> Unit,
     onTauRecoveryChange: (Double) -> Unit,
     onKInChange: (Double) -> Unit,
@@ -180,8 +190,10 @@ fun ConfigurationScreenLayout(
                         when (selectedTabIndex) {
                             0 -> ConfigurationTab(
                                 configuration = configuration,
+                                karooFtp = karooFtp,
                                 requirements = requirements,
                                 onCriticalPowerChange = onCriticalPowerChange,
+                                onUseKarooFtpForCriticalPowerChange = onUseKarooFtpForCriticalPowerChange,
                                 onAnaerobicCapacityChange = onAnaerobicCapacityChange,
                                 onTauRecoveryChange = onTauRecoveryChange,
                                 onKInChange = onKInChange,
@@ -231,8 +243,10 @@ fun ConfigurationScreenLayout(
 @Composable
 fun ConfigurationTab(
     configuration: WPrimeConfiguration,
+    karooFtp: Int?,
     requirements: ModelParameterRequirements,
     onCriticalPowerChange: (Double) -> Unit,
+    onUseKarooFtpForCriticalPowerChange: (Boolean) -> Unit,
     onAnaerobicCapacityChange: (Double) -> Unit,
     onTauRecoveryChange: (Double) -> Unit,
     onKInChange: (Double) -> Unit,
@@ -255,11 +269,64 @@ fun ConfigurationTab(
             onModelSelected = onModelSelected,
         )
 
+        val usesKarooFtp = configuration.criticalPowerSource == CriticalPowerSource.KAROO_FTP
+        val effectiveCriticalPower = configuration.resolveCriticalPower(karooFtp)
+        val calculatedCriticalPower = karooFtp?.let { it * KAROO_FTP_TO_CRITICAL_POWER_FACTOR }
+        val criticalPowerDescription = when {
+            usesKarooFtp && calculatedCriticalPower != null ->
+                "Karoo FTP ${karooFtp}W x ${KAROO_FTP_TO_CRITICAL_POWER_FACTOR} = ${calculatedCriticalPower.toInt()}W"
+
+            usesKarooFtp ->
+                "Karoo FTP unavailable; using saved manual CP until profile data is available"
+
+            calculatedCriticalPower != null ->
+                "Karoo FTP would calculate ${calculatedCriticalPower.toInt()}W"
+
+            else ->
+                "Manual value"
+        }
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(14.dp),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(modifier = Modifier.fillMaxWidth(0.75f)) {
+                    Text(
+                        text = "Use Karoo FTP",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = "Calculate CP from the Karoo profile FTP",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = usesKarooFtp,
+                    onCheckedChange = onUseKarooFtpForCriticalPowerChange,
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = MaterialTheme.colorScheme.primary,
+                        checkedTrackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.45f),
+                    ),
+                )
+            }
+        }
+
         CompactSettingField(
             title = "Critical Power (CP)",
-            value = configuration.criticalPower,
+            description = criticalPowerDescription,
+            value = effectiveCriticalPower,
             unit = "W",
             onValueChange = onCriticalPowerChange,
+            enabled = !usesKarooFtp,
         )
         CompactSettingField(
             title = "Anaerobic Capacity (W')",
@@ -600,6 +667,7 @@ fun ConfigurationScreenPreview() {
             isLoading = false,
             configuration = WPrimeConfiguration(
                 criticalPower = 280.0,
+                criticalPowerSource = CriticalPowerSource.MANUAL,
                 anaerobicCapacity = 22000.0,
                 tauRecovery = 320.0,
                 kIn = 0.002,
@@ -608,7 +676,9 @@ fun ConfigurationScreenPreview() {
                 showArrow = true,
                 useColors = true,
             ),
+            karooFtp = 295,
             onCriticalPowerChange = {},
+            onUseKarooFtpForCriticalPowerChange = {},
             onAnaerobicCapacityChange = {},
             onTauRecoveryChange = {},
             onKInChange = {},

--- a/app/src/main/kotlin/com/itl/wprimeext/extension/CriticalPowerResolver.kt
+++ b/app/src/main/kotlin/com/itl/wprimeext/extension/CriticalPowerResolver.kt
@@ -1,0 +1,13 @@
+package com.itl.wprimeext.extension
+
+fun WPrimeConfiguration.resolveCriticalPower(karooFtp: Int?): Double {
+    val calculatedCriticalPower = karooFtp
+        ?.takeIf { it > 0 }
+        ?.let { it * KAROO_FTP_TO_CRITICAL_POWER_FACTOR }
+
+    return if (criticalPowerSource == CriticalPowerSource.KAROO_FTP && calculatedCriticalPower != null) {
+        calculatedCriticalPower
+    } else {
+        criticalPower
+    }
+}

--- a/app/src/main/kotlin/com/itl/wprimeext/extension/Extensions.kt
+++ b/app/src/main/kotlin/com/itl/wprimeext/extension/Extensions.kt
@@ -4,6 +4,7 @@ import io.hammerhead.karooext.KarooSystemService
 import io.hammerhead.karooext.models.KarooEvent
 import io.hammerhead.karooext.models.OnStreamState
 import io.hammerhead.karooext.models.StreamState
+import io.hammerhead.karooext.models.UserProfile
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
@@ -20,6 +21,16 @@ fun KarooSystemService.streamDataFlow(dataTypeId: String): Flow<StreamState> = c
 
 inline fun <reified T : KarooEvent> KarooSystemService.consumerFlow(): Flow<T> = callbackFlow {
     val listenerId = addConsumer<T> {
+        trySend(it)
+    }
+    awaitClose {
+        removeConsumer(listenerId)
+    }
+}
+
+fun KarooSystemService.userProfileFlow(): Flow<UserProfile?> = callbackFlow {
+    trySend(null)
+    val listenerId = addConsumer<UserProfile> {
         trySend(it)
     }
     awaitClose {

--- a/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeDataTypeBase.kt
+++ b/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeDataTypeBase.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
@@ -125,19 +126,23 @@ abstract class WPrimeDataTypeBase(
             CoroutineScope(Dispatchers.IO).launch {
                 // Configure the calculator with persistent settings
                 launch {
-                    wprimeSettings.configuration.collect { config ->
-                        wprimeCalculator.updateConfiguration(
-                            config.criticalPower,
-                            config.anaerobicCapacity,
-                            config.tauRecovery,
-                            config.kIn,
-                            config.modelType,
-                        )
-                        WPrimeLogger.d(
-                            WPrimeLogger.Module.DATA_TYPE,
-                            "Setting Calculator Configuration for $typeId - Model: ${config.modelType}, CP: ${config.criticalPower}W, W': ${config.anaerobicCapacity}J, Tau: ${config.tauRecovery}s, kIn: ${config.kIn}",
-                        )
-                    }
+                    wprimeSettings.configuration
+                        .combine(karooSystem.userProfileFlow()) { config, userProfile ->
+                            Pair(config, config.resolveCriticalPower(userProfile?.ftp))
+                        }
+                        .collect { (config, criticalPower) ->
+                            wprimeCalculator.updateConfiguration(
+                                criticalPower,
+                                config.anaerobicCapacity,
+                                config.tauRecovery,
+                                config.kIn,
+                                config.modelType,
+                            )
+                            WPrimeLogger.d(
+                                WPrimeLogger.Module.DATA_TYPE,
+                                "Setting Calculator Configuration for $typeId - Model: ${config.modelType}, CP: ${criticalPower}W, CP source: ${config.criticalPowerSource}, W': ${config.anaerobicCapacity}J, Tau: ${config.tauRecovery}s, kIn: ${config.kIn}",
+                            )
+                        }
                 }
 
                 // Emit initial (full) W' in stream units (percent or Joules)

--- a/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeExtension.kt
+++ b/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeExtension.kt
@@ -100,7 +100,7 @@ class WPrimeExtension : KarooExtension("wprime-id", BuildConfig.VERSION_NAME) {
             val initialConfig = settings.configuration.first()
             var recordFitEnabled = initialConfig.recordFit
             val calculator = WPrimeCalculator(
-                criticalPower = initialConfig.criticalPower,
+                criticalPower = initialConfig.resolveCriticalPower(null),
                 anaerobicCapacity = initialConfig.anaerobicCapacity,
                 tauRecovery = initialConfig.tauRecovery,
                 kIn = initialConfig.kIn,
@@ -108,16 +108,20 @@ class WPrimeExtension : KarooExtension("wprime-id", BuildConfig.VERSION_NAME) {
             )
             // Keep calculator & toggle updated with config changes
             launch {
-                settings.configuration.collect { cfg ->
-                    calculator.updateConfiguration(
-                        cfg.criticalPower,
-                        cfg.anaerobicCapacity,
-                        cfg.tauRecovery,
-                        cfg.kIn,
-                        cfg.modelType,
-                    )
-                    recordFitEnabled = cfg.recordFit
-                }
+                settings.configuration
+                    .combine(karooSystem.userProfileFlow()) { cfg, userProfile ->
+                        Pair(cfg, cfg.resolveCriticalPower(userProfile?.ftp))
+                    }
+                    .collect { (cfg, criticalPower) ->
+                        calculator.updateConfiguration(
+                            criticalPower,
+                            cfg.anaerobicCapacity,
+                            cfg.tauRecovery,
+                            cfg.kIn,
+                            cfg.modelType,
+                        )
+                        recordFitEnabled = cfg.recordFit
+                    }
             }
 
             // Recovery ticker for FIT: when the power stream is silent (autopause / stop),

--- a/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeSettings.kt
+++ b/app/src/main/kotlin/com/itl/wprimeext/extension/WPrimeSettings.kt
@@ -20,6 +20,8 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 @Serializable
 enum class AlertType { DROP, REPLENISH }
 
+enum class CriticalPowerSource { MANUAL, KAROO_FTP }
+
 @Serializable
 data class WPrimeAlert(
     val id: String,
@@ -30,6 +32,7 @@ data class WPrimeAlert(
 
 data class WPrimeConfiguration(
     val criticalPower: Double = 250.0,
+    val criticalPowerSource: CriticalPowerSource = CriticalPowerSource.MANUAL,
     val anaerobicCapacity: Double = 12000.0,
     val tauRecovery: Double = 300.0,
     val kIn: Double = 0.002,
@@ -40,10 +43,13 @@ data class WPrimeConfiguration(
     val alerts: List<WPrimeAlert> = emptyList(),
 )
 
+const val KAROO_FTP_TO_CRITICAL_POWER_FACTOR = 0.95
+
 class WPrimeSettings(private val context: Context) {
 
     companion object {
         private val CRITICAL_POWER_KEY = doublePreferencesKey("critical_power")
+        private val CRITICAL_POWER_SOURCE_KEY = stringPreferencesKey("critical_power_source")
         private val ANAEROBIC_CAPACITY_KEY = doublePreferencesKey("anaerobic_capacity")
         private val TAU_RECOVERY_KEY = doublePreferencesKey("tau_recovery")
         private val K_IN_KEY = doublePreferencesKey("k_in")
@@ -74,6 +80,9 @@ class WPrimeSettings(private val context: Context) {
 
         val config = WPrimeConfiguration(
             criticalPower = preferences[CRITICAL_POWER_KEY] ?: 250.0,
+            criticalPowerSource = preferences[CRITICAL_POWER_SOURCE_KEY]
+                ?.let { runCatching { CriticalPowerSource.valueOf(it) }.getOrNull() }
+                ?: CriticalPowerSource.MANUAL,
             anaerobicCapacity = preferences[ANAEROBIC_CAPACITY_KEY] ?: 12000.0,
             tauRecovery = preferences[TAU_RECOVERY_KEY] ?: 300.0,
             kIn = preferences[K_IN_KEY] ?: 0.002,
@@ -92,7 +101,7 @@ class WPrimeSettings(private val context: Context) {
         }
         WPrimeLogger.d(
             WPrimeLogger.Module.SETTINGS,
-            "Loaded configuration - Model: ${config.modelType}, CP: ${config.criticalPower}, W': ${config.anaerobicCapacity}, Tau: ${config.tauRecovery}, kIn: ${config.kIn}, recordFit: ${config.recordFit}, showArrow: ${config.showArrow}, useColors: ${config.useColors}, alerts: ${config.alerts.size}",
+            "Loaded configuration - Model: ${config.modelType}, CP: ${config.criticalPower}, CP source: ${config.criticalPowerSource}, W': ${config.anaerobicCapacity}, Tau: ${config.tauRecovery}, kIn: ${config.kIn}, recordFit: ${config.recordFit}, showArrow: ${config.showArrow}, useColors: ${config.useColors}, alerts: ${config.alerts.size}",
         )
 
         config
@@ -104,6 +113,14 @@ class WPrimeSettings(private val context: Context) {
             preferences[CRITICAL_POWER_KEY] = power
         }
         WPrimeLogger.i(WPrimeLogger.Module.SETTINGS, LogConstants.SETTINGS_SAVED + " - Critical Power")
+    }
+
+    suspend fun updateCriticalPowerSource(source: CriticalPowerSource) {
+        WPrimeLogger.d(WPrimeLogger.Module.SETTINGS, "Updating CP source: ${source.name}")
+        context.dataStore.edit { preferences ->
+            preferences[CRITICAL_POWER_SOURCE_KEY] = source.name
+        }
+        WPrimeLogger.i(WPrimeLogger.Module.SETTINGS, LogConstants.SETTINGS_SAVED + " - Critical Power Source")
     }
 
     suspend fun updateAnaerobicCapacity(capacity: Double) {

--- a/app/src/main/kotlin/com/itl/wprimeext/ui/viewmodel/WPrimeConfigViewModel.kt
+++ b/app/src/main/kotlin/com/itl/wprimeext/ui/viewmodel/WPrimeConfigViewModel.kt
@@ -4,10 +4,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.itl.wprimeext.extension.AlertType
+import com.itl.wprimeext.extension.CriticalPowerSource
 import com.itl.wprimeext.extension.WPrimeAlert
 import com.itl.wprimeext.extension.WPrimeConfiguration
 import com.itl.wprimeext.extension.WPrimeModelType
 import com.itl.wprimeext.extension.WPrimeSettings
+import com.itl.wprimeext.extension.resolveCriticalPower
+import com.itl.wprimeext.extension.userProfileFlow
+import io.hammerhead.karooext.KarooSystemService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,10 +21,16 @@ import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalUuidApi::class)
-class WPrimeConfigViewModel(private val settings: WPrimeSettings) : ViewModel() {
+class WPrimeConfigViewModel(
+    private val settings: WPrimeSettings,
+    private val karooSystem: KarooSystemService,
+) : ViewModel() {
 
     private val _configuration = MutableStateFlow(WPrimeConfiguration())
     val configuration: StateFlow<WPrimeConfiguration> = _configuration.asStateFlow()
+
+    private val _karooFtp = MutableStateFlow<Int?>(null)
+    val karooFtp: StateFlow<Int?> = _karooFtp.asStateFlow()
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -30,12 +40,39 @@ class WPrimeConfigViewModel(private val settings: WPrimeSettings) : ViewModel() 
             _configuration.value = settings.configuration.first()
             _isLoading.value = false
         }
+        runCatching { karooSystem.connect() }
+        viewModelScope.launch {
+            karooSystem.userProfileFlow().collect { profile ->
+                _karooFtp.value = profile?.ftp?.takeIf { it > 0 }
+            }
+        }
     }
 
     fun updateCriticalPower(power: Double) {
         viewModelScope.launch {
             settings.updateCriticalPower(power)
             _configuration.value = _configuration.value.copy(criticalPower = power)
+        }
+    }
+
+    fun updateUseKarooFtpForCriticalPower(enabled: Boolean) {
+        viewModelScope.launch {
+            val currentConfig = _configuration.value
+            val source = if (enabled) CriticalPowerSource.KAROO_FTP else CriticalPowerSource.MANUAL
+            val manualCriticalPower = if (enabled) {
+                currentConfig.criticalPower
+            } else {
+                currentConfig.resolveCriticalPower(_karooFtp.value)
+            }
+
+            if (!enabled) {
+                settings.updateCriticalPower(manualCriticalPower)
+            }
+            settings.updateCriticalPowerSource(source)
+            _configuration.value = currentConfig.copy(
+                criticalPower = manualCriticalPower,
+                criticalPowerSource = source,
+            )
         }
     }
 
@@ -123,13 +160,21 @@ class WPrimeConfigViewModel(private val settings: WPrimeSettings) : ViewModel() 
             _configuration.value = _configuration.value.copy(alerts = updatedAlerts)
         }
     }
+
+    override fun onCleared() {
+        runCatching { karooSystem.disconnect() }
+        super.onCleared()
+    }
 }
 
-class WPrimeConfigViewModelFactory(private val settings: WPrimeSettings) : ViewModelProvider.Factory {
+class WPrimeConfigViewModelFactory(
+    private val settings: WPrimeSettings,
+    private val karooSystem: KarooSystemService,
+) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(WPrimeConfigViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return WPrimeConfigViewModel(settings) as T
+            return WPrimeConfigViewModel(settings, karooSystem) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }


### PR DESCRIPTION
## Summary

Adds an optional Karoo FTP-based Critical Power source in the W Prime configuration screen.

## Changes

- Adds a persisted `CriticalPowerSource` setting for manual vs Karoo FTP-derived CP.
- Reads `UserProfile.ftp` from `karoo-ext` and calculates CP as `FTP x 0.95`.
- Shows a `Use Karoo FTP` toggle; when enabled the CP field is read-only and displays the calculated value.
- When the toggle is disabled, the calculated CP is saved as the new manual value so it can be edited from there.
- Applies the same effective CP to data-field calculations and FIT recording.

## Validation

- `./gradlew.bat spotlessApply`
- `./gradlew.bat build`

## Notes

ADB/Karoo visual validation was not run because `adb` was not available in the PATH for this session.